### PR TITLE
gajoenのapiをライブラリとして実装する

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,6 @@ module RubyGettingStarted
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
-
+    config.autoload_paths += %W(#{config.root}/lib)
   end
 end

--- a/lib/giftee-api.rb
+++ b/lib/giftee-api.rb
@@ -1,0 +1,1 @@
+require 'giftee/gajoen'

--- a/lib/giftee/gajoen.rb
+++ b/lib/giftee/gajoen.rb
@@ -1,0 +1,62 @@
+require 'json'
+require 'net/http'
+require 'uri'
+require 'active_support/core_ext/hash/except.rb'
+
+module Giftee
+  module Gajoen
+    class Client
+      attr_accessor :domain, :token
+
+      def initialize(options = {})
+        options.each do |key, value|
+          instance_variable_set("@#{key}", value)
+        end
+      end
+
+      def http
+        http = Net::HTTP.new(domain, 443)
+        http.use_ssl = true
+        http
+      end
+
+      # @param [Hash] params
+      def get(params)
+        return nil if params.key?('brand_id') && params.key?('request_code')
+        return nil unless valid_request_code?(params[:request_code])
+
+        req = Net::HTTP::Get.new(File.join('/brands', params[:brand_id].to_s, 'tickets', params[:request_code]))
+        req.initialize_http_header(headers)
+
+        res = http.request(req)
+        JSON.parse(res.body)
+      end
+
+      # @param [Hash] params
+      def post(params)
+        return nil if params.key?('brand_id') && params.key?('item_id') && params.key?('request_code')
+        return nil unless valid_request_code?(params[:request_code])
+
+        req = Net::HTTP::Post.new(File.join('/brands', params[:brand_id].to_s, 'tickets'))
+        req.body = params.except(:brand_id).to_json
+        req.initialize_http_header(headers)
+
+        res = http.request(req)
+        JSON.parse(res.body)
+      end
+
+      def headers
+        {
+          'X-Giftee' => 1.to_s,
+          'Authorization' => "Bearer #{token}",
+          'Content-Type' => 'application/json',
+        }
+      end
+
+      def valid_request_code?(request_code)
+        re = /[a-zA-Z0-9_-]{1,50}/
+        re.match?(request_code)
+      end
+    end
+  end
+end

--- a/lib/giftee/gajoen.rb
+++ b/lib/giftee/gajoen.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/hash/except.rb'
 module Giftee
   module Gajoen
     class Client
-      attr_accessor :domain, :token
+      attr_reader :domain, :token
 
       def initialize(options = {})
         options.each do |key, value|

--- a/lib/giftee/gajoen.rb
+++ b/lib/giftee/gajoen.rb
@@ -14,12 +14,6 @@ module Giftee
         end
       end
 
-      def http
-        http = Net::HTTP.new(domain, 443)
-        http.use_ssl = true
-        http
-      end
-
       # @param [Hash] params
       def get(params)
         return nil if params.key?('brand_id') && params.key?('request_code')
@@ -43,6 +37,14 @@ module Giftee
 
         res = http.request(req)
         JSON.parse(res.body)
+      end
+
+      private
+
+      def http
+        http = Net::HTTP.new(domain, 443)
+        http.use_ssl = true
+        http
       end
 
       def headers


### PR DESCRIPTION
## 実装の背景・目的

gajoenへRubyでアクセスできるようにする

## やったこと

- `get` と `post` のメソッドでチケットの参照/作成ができるようにした

## 補足

- `domain` と `token` はクライアントをインスタンス化するときに環境変数経由で設定する

- 補足事項があれば
- [ ] 例外処理はまだ実装していません