### PR TITLE
Add title to message

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -35,6 +35,7 @@ class WebhookController < ApplicationController
               altText: s.message,
               template: {
                 type: "buttons",
+                title: s.name,
                 text: s.message,
                 actions: [
                   {


### PR DESCRIPTION
## 実装の背景・目的

クーポン名をメッセージのタイトルとして表示する（「友だち登録記念クーポン」の部分）

## やったこと

- `title` 属性を追加

## キャプチャ

![iOS の画像](https://user-images.githubusercontent.com/11751679/141971664-087a444b-95d1-45e9-878e-f572a901aac3.png)

